### PR TITLE
fix/commonjs-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,36 +29,41 @@ $ npm install openapi-mock-express-middleware --save-dev
 ### Simple Config
 ```javascript
 const express = require('express');
-const mockServer = require('openapi-mock-express-middleware');
+const { createMockMiddleware } = require('openapi-mock-express-middleware');
 
 const app = express();
+
 app.use(
-  '/api' /* root path for the mock server */,
-  mockServer({ file: '/absolute/path/to/your/openapi/spec.yml' })
+  '/api', // root path for the mock server
+  createMockMiddleware({ file: '/absolute/path/to/your/openapi/spec.yml' }),
 );
-app.listen(80, () => console.log('Server listening on port 80'))''
+
+app.listen(80, () => console.log('Server listening on port 80'));
 ```
 
 ### Advanced Config
 The middleware uses [json-schmea-faker](https://github.com/json-schema-faker/json-schema-faker) under the hood. To configure it, you can pass locale and the options object to the factory function. (The full list of available options can be seen [here](https://github.com/json-schema-faker/json-schema-faker/tree/master/docs#available-options))
+
 ```javascript
 const express = require('express');
-const mockServer = require('openapi-mock-express-middleware');
+const { createMockMiddleware } = require('openapi-mock-express-middleware');
 
 const app = express();
+
 app.use(
-  '/api', // root path for the mock server
-  mockServer({
-    file: '/absolute/path/to/your/openapi/spec.yml'
+  '/api',
+  createMockMiddleware({
+    file: '/absolute/path/to/your/openapi/spec.yml',
     locale: 'ru', // json-schema-faker locale, default to 'en'
-    {
+    options: { // json-schema-faker options
       alwaysFakeOptionals: true,
-      useDefaultValue: true,
+      useExamplesValue: true,
       // ...
-    }, // json-schema-faker options
-  })
+    },
+  }),
 );
-app.listen(80, () => console.log('Server listening on port 80'))''
+
+app.listen(80, () => console.log('Server listening on port 80'));
 ```
 
 ## Mock data
@@ -230,4 +235,3 @@ Please take a moment to read our contributing guidelines if you haven't yet done
 [npm-url]: https://npmjs.com/package/openapi-mock-express-middleware
 [deps]: https://david-dm.org/aleksandryackovlev/openapi-mock-express-middleware.svg
 [deps-url]: https://david-dm.org/aleksandryackovlev/openapi-mock-express-middleware
-

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -2,11 +2,11 @@ import path from 'path';
 
 import { Router } from 'express';
 
-import createMiddleware from './index';
+import { createMockMiddleware } from './index';
 
-describe('createMiddleware', () => {
+describe('createMockMiddleware', () => {
   it('should return an instance of the express router', async () => {
-    const middleware = createMiddleware({
+    const middleware = createMockMiddleware({
       file: path.resolve(__dirname, '../test/fixtures/petstore.yaml'),
     });
 
@@ -15,7 +15,7 @@ describe('createMiddleware', () => {
 
   it('should throw an error if the given file does not exist', () => {
     try {
-      createMiddleware({
+      createMockMiddleware({
         file: path.resolve(__dirname, '../test/fixtures/petstore_not_exist.yaml'),
       });
       throw new Error('exit');

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export interface MiddlewareOptions {
   options?: Partial<JSFOptions>;
 }
 
-const createMiddleware = ({
+export const createMockMiddleware = ({
   file,
   locale = 'en',
   options = {},
@@ -52,5 +52,3 @@ const createMiddleware = ({
 
   return router;
 };
-
-export default createMiddleware;

--- a/test/helpers/app.ts
+++ b/test/helpers/app.ts
@@ -2,11 +2,11 @@ import path from 'path';
 
 import express from 'express';
 
-import createMiddleware from '../../src';
+import { createMockMiddleware } from '../../src';
 
 const app = express();
 
-const middleware = createMiddleware({
+const middleware = createMockMiddleware({
   file: path.resolve(__dirname, '../fixtures/petstore.yaml'),
 });
 


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

CommonJS users needed to access *createMiddleware* function within *default* property as default TypeScript export was not properly built for a CommonJS use:

https://github.com/aleksandryackovlev/openapi-mock-express-middleware/issues/9

This proposal is somewhere between a bug fix and a feature as there was not really a bug in this module and my work is not strictly a feature.

There also were some typos in the *Usage* section of the *README* that have been updated accordingly.

### Breaking Changes
If a new release is built from this PR, users will have to change the way they access the entrypoint and the *createMockMiddleware* function like this:

```javascript
// before
const express = require('express');
const mockServer = require('openapi-mock-express-middleware');

const app = express();
app.use(
  '/api' /* root path for the mock server */,
  mockServer.default({ file: '/absolute/path/to/your/openapi/spec.yml' })
);

// ...

// after
const express = require('express');
const { createMockMiddleware } = require('openapi-mock-express-middleware');

const app = express();

app.use(
  '/api', // root path for the mock server
  createMockMiddleware({ file: '/absolute/path/to/your/openapi/spec.yml' }),
);

// ...
```

### Additional Info
**Tests + build OK**

I hope it could help you. You may like another name for *createMockMiddleware*, I don't know, find it meaninful. Please let me know.