### PR TITLE
Feature/in memory doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.0.3](https://github.com/aleksandryackovlev/openapi-mock-express-middleware/compare/v2.0.2...v2.0.3) (2021-06-10)
+
 ### [2.0.2](https://github.com/aleksandryackovlev/openapi-mock-express-middleware/compare/v2.0.1...v2.0.2) (2021-03-08)
 
 ### [2.0.1](https://github.com/aleksandryackovlev/openapi-mock-express-middleware/compare/v2.0.0...v2.0.1) (2021-02-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [2.0.3](https://github.com/aleksandryackovlev/openapi-mock-express-middleware/compare/v2.0.2...v2.0.3) (2021-06-10)
-
 ### [2.0.2](https://github.com/aleksandryackovlev/openapi-mock-express-middleware/compare/v2.0.1...v2.0.2) (2021-03-08)
 
 ### [2.0.1](https://github.com/aleksandryackovlev/openapi-mock-express-middleware/compare/v2.0.0...v2.0.1) (2021-02-17)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-mock-express-middleware",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Generates an express mock server from an Open API spec",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,28 +15,30 @@ import {
 import { JSFOptions, JSFCallback } from './utils';
 
 export interface MiddlewareOptions {
-  file: string | OpenAPIV3.Document;
-  inMemory: boolean;
+  file: string;
+  spec?: string | OpenAPIV3.Document;
   locale?: string;
   options?: Partial<JSFOptions>;
   jsfCallback?: JSFCallback;
 }
 
 export const createMockMiddleware = ({
+  /**
+   * @deprecated
+   */
   file,
-  inMemory = false,
+  spec,
   locale = 'en',
   options = {},
   jsfCallback,
 }: MiddlewareOptions): express.Router => {
-  if (!inMemory && !fs.existsSync(file as string)) {
-    throw new Error(`OpenAPI spec not found at location: ${file}`);
-  } else if (inMemory && !file) {
-    throw new Error(`OpenAPI spec not provided`);
+  const docSpec = !spec ? file : spec;
+  if (typeof docSpec === 'string' && !fs.existsSync(docSpec)) {
+    throw new Error(`OpenAPI spec not found at location: ${docSpec}`);
   }
 
   const router = createRouter();
-  const operations = createOperations({ file, inMemory, locale, options, callback: jsfCallback });
+  const operations = createOperations({ spec: docSpec, locale, options, callback: jsfCallback });
 
   router.use('/{0,}', async (req, res, next) => {
     res.locals.operation = await operations.match(req);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { JSFOptions, JSFCallback } from './utils';
 
 export interface MiddlewareOptions {
   file: string;
+  inMemory?: boolean;
   locale?: string;
   options?: Partial<JSFOptions>;
   jsfCallback?: JSFCallback;
@@ -22,16 +23,19 @@ export interface MiddlewareOptions {
 
 export const createMockMiddleware = ({
   file,
+  inMemory = false,
   locale = 'en',
   options = {},
   jsfCallback,
 }: MiddlewareOptions): express.Router => {
-  if (!fs.existsSync(file)) {
+  if (!inMemory && !fs.existsSync(file)) {
     throw new Error(`OpenAPI spec not found at location: ${file}`);
+  } else if (inMemory && !file) {
+    throw new Error(`OpenAPI spec not provided`);
   }
 
   const router = createRouter();
-  const operations = createOperations({ file, locale, options, callback: jsfCallback });
+  const operations = createOperations({ file, inMemory, locale, options, callback: jsfCallback });
 
   router.use('/{0,}', async (req, res, next) => {
     res.locals.operation = await operations.match(req);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 
 import express from 'express';
+import type { OpenAPIV3 } from 'openapi-types';
 
 import createRouter from './router';
 import { createOperations } from './operations';
@@ -14,8 +15,8 @@ import {
 import { JSFOptions, JSFCallback } from './utils';
 
 export interface MiddlewareOptions {
-  file: string;
-  inMemory?: boolean;
+  file: string | OpenAPIV3.Document;
+  inMemory: boolean;
   locale?: string;
   options?: Partial<JSFOptions>;
   jsfCallback?: JSFCallback;
@@ -28,7 +29,7 @@ export const createMockMiddleware = ({
   options = {},
   jsfCallback,
 }: MiddlewareOptions): express.Router => {
-  if (!inMemory && !fs.existsSync(file)) {
+  if (!inMemory && !fs.existsSync(file as string)) {
     throw new Error(`OpenAPI spec not found at location: ${file}`);
   } else if (inMemory && !file) {
     throw new Error(`OpenAPI spec not provided`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
 import { JSFOptions, JSFCallback } from './utils';
 
 export interface MiddlewareOptions {
-  file: string;
+  file?: string;
   spec?: string | OpenAPIV3.Document;
   locale?: string;
   options?: Partial<JSFOptions>;
@@ -35,6 +35,8 @@ export const createMockMiddleware = ({
   const docSpec = !spec ? file : spec;
   if (typeof docSpec === 'string' && !fs.existsSync(docSpec)) {
     throw new Error(`OpenAPI spec not found at location: ${docSpec}`);
+  } else if (docSpec === undefined) {
+    throw new Error(`OpenAPI spec not provided`);
   }
 
   const router = createRouter();

--- a/src/operations/operations.ts
+++ b/src/operations/operations.ts
@@ -14,33 +14,26 @@ import { Operation, createOperation } from './operation';
 export class Operations {
   operations: Operation[] | null = null;
 
-  file: string | OpenAPIV3.Document;
-
-  inMemory: boolean;
+  spec: string | OpenAPIV3.Document;
 
   locale: string;
 
   generator: JSF;
 
   constructor({
-    file,
-    inMemory,
+    spec,
     locale,
     options,
     callback,
   }: {
-    file: string | OpenAPIV3.Document;
-    inMemory: boolean;
+    spec: string | OpenAPIV3.Document;
     locale: string;
     options: Partial<JSFOptions>;
     callback?: JSFCallback;
   }) {
-    this.file = file;
-    this.inMemory = inMemory;
+    this.spec = spec;
     this.locale = locale;
-    if (!inMemory) {
-      this.watch();
-    }
+    this.watch();
     this.generator = createGenerator(locale, options, callback);
   }
 
@@ -49,15 +42,15 @@ export class Operations {
   }
 
   watch(): void {
-    if (this.inMemory) return;
+    if (typeof this.spec !== 'string') return;
 
-    const watcher = chokidar.watch(path.dirname(this.file as string));
+    const watcher = chokidar.watch(path.dirname(this.spec));
 
     watcher.on('all', () => this.reset());
   }
 
   async compile(): Promise<void> {
-    const api = await SwaggerParser.dereference(this.file);
+    const api = await SwaggerParser.dereference(this.spec);
 
     this.operations = toPairs(api.paths as OpenAPIV3.PathsObject).reduce(
       (result: Operation[], [pathName, pathOperations]) => [
@@ -109,15 +102,13 @@ export class Operations {
 }
 
 export const createOperations = ({
-  file,
-  inMemory,
+  spec,
   locale,
   options,
   callback,
 }: {
-  file: string | OpenAPIV3.Document;
-  inMemory: boolean;
+  spec: string | OpenAPIV3.Document;
   locale: string;
   options: Partial<JSFOptions>;
   callback?: JSFCallback;
-}): Operations => new Operations({ file, inMemory, locale, options, callback });
+}): Operations => new Operations({ spec, locale, options, callback });

--- a/src/operations/operations.ts
+++ b/src/operations/operations.ts
@@ -14,7 +14,7 @@ import { Operation, createOperation } from './operation';
 export class Operations {
   operations: Operation[] | null = null;
 
-  file: string;
+  file: string | OpenAPIV3.Document;
 
   inMemory: boolean;
 
@@ -29,7 +29,7 @@ export class Operations {
     options,
     callback,
   }: {
-    file: string;
+    file: string | OpenAPIV3.Document;
     inMemory: boolean;
     locale: string;
     options: Partial<JSFOptions>;
@@ -51,7 +51,7 @@ export class Operations {
   watch(): void {
     if (this.inMemory) return;
 
-    const watcher = chokidar.watch(path.dirname(this.file));
+    const watcher = chokidar.watch(path.dirname(this.file as string));
 
     watcher.on('all', () => this.reset());
   }
@@ -115,7 +115,7 @@ export const createOperations = ({
   options,
   callback,
 }: {
-  file: string;
+  file: string | OpenAPIV3.Document;
   inMemory: boolean;
   locale: string;
   options: Partial<JSFOptions>;

--- a/src/operations/operations.ts
+++ b/src/operations/operations.ts
@@ -15,6 +15,7 @@ export class Operations {
   operations: Operation[] | null = null;
 
   file: string;
+  inMemory: boolean;
 
   locale: string;
 
@@ -22,18 +23,22 @@ export class Operations {
 
   constructor({
     file,
+    inMemory,
     locale,
     options,
     callback,
   }: {
     file: string;
+    inMemory: boolean;
     locale: string;
     options: Partial<JSFOptions>;
     callback?: JSFCallback;
   }) {
     this.file = file;
     this.locale = locale;
-    this.watch();
+    if (!inMemory) {
+      this.watch();
+    }
     this.generator = createGenerator(locale, options, callback);
   }
 
@@ -42,6 +47,8 @@ export class Operations {
   }
 
   watch(): void {
+    if (this.inMemory) return;
+
     const watcher = chokidar.watch(path.dirname(this.file));
 
     watcher.on('all', () => this.reset());
@@ -101,12 +108,14 @@ export class Operations {
 
 export const createOperations = ({
   file,
+  inMemory,
   locale,
   options,
   callback,
 }: {
   file: string;
+  inMemory: boolean;
   locale: string;
   options: Partial<JSFOptions>;
   callback?: JSFCallback;
-}): Operations => new Operations({ file, locale, options, callback });
+}): Operations => new Operations({ file, inMemory, locale, options, callback });

--- a/src/operations/operations.ts
+++ b/src/operations/operations.ts
@@ -35,6 +35,7 @@ export class Operations {
     callback?: JSFCallback;
   }) {
     this.file = file;
+    this.inMemory = inMemory;
     this.locale = locale;
     if (!inMemory) {
       this.watch();

--- a/src/operations/operations.ts
+++ b/src/operations/operations.ts
@@ -15,6 +15,7 @@ export class Operations {
   operations: Operation[] | null = null;
 
   file: string;
+
   inMemory: boolean;
 
   locale: string;


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

In my use case, I am using json-refs to generate documents on the fly and modify the generated object and add some parameters like server, port, and base path. 
In many cases, the doc is not a physical file, like when some parameters in docs need to be dynamic and change via environment variables or dynamically generating docs from other tools.

Tools used internally allowing to use DocumentObjects but the interface is forcing to just use file path which is a string. this PR is allowing to put DocumentObject as a file.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->
No breaking change. it is backward compatible as the `inMemory` variable set to false by default, which means file path as string
 
### Additional Info
