### PR TITLE
fix(validator): set coerceTypes to parse arrays

### DIFF
--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -2,7 +2,7 @@ import Ajv from 'ajv';
 
 const ajv = new Ajv({
   strict: false,
-  coerceTypes: true,
+  coerceTypes: 'array',
   formats: {
     int32: true,
     int64: true,


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

https://github.com/aleksandryackovlev/openapi-mock-express-middleware/issues/31: If type of some `bar` property is `array` and I make `GET /foo?bar=1`, it causes validation error, but `bar=1` is equal to `bar[]=1` if there is one item in array.
