### PR TITLE
feat(operations): add operations sort according to express

### DIFF
--- a/src/operations/operations.ts
+++ b/src/operations/operations.ts
@@ -7,7 +7,7 @@ import { Request } from 'express';
 import SwaggerParser from '@apidevtools/swagger-parser';
 import { get, toPairs } from 'lodash';
 
-import { createGenerator, JSFOptions, JSF, JSFCallback } from '../utils';
+import { createGenerator, JSFOptions, JSF, JSFCallback, expressRouteComparator } from '../utils';
 
 import { Operation, createOperation } from './operation';
 
@@ -49,17 +49,19 @@ export class Operations {
   async compile(): Promise<void> {
     const api = await SwaggerParser.dereference(this.spec);
 
-    this.operations = toPairs(api.paths as OpenAPIV3.PathsObject).reduce(
-      (result: Operation[], [pathName, pathOperations]) => [
-        ...result,
-        ...this.compileFromPath(
-          pathName,
-          pathOperations as OpenAPIV3.PathItemObject,
-          get(api, 'components.securitySchemes') as SecuritySchemes
-        ),
-      ],
-      []
-    );
+    this.operations = toPairs(api.paths as OpenAPIV3.PathsObject)
+      .sort(expressRouteComparator)
+      .reduce(
+        (result: Operation[], [pathName, pathOperations]) => [
+          ...result,
+          ...this.compileFromPath(
+            pathName,
+            pathOperations as OpenAPIV3.PathItemObject,
+            get(api, 'components.securitySchemes') as SecuritySchemes
+          ),
+        ],
+        []
+      );
   }
 
   /* eslint-disable class-methods-use-this */

--- a/src/utils/comparator.spec.ts
+++ b/src/utils/comparator.spec.ts
@@ -1,0 +1,39 @@
+import { expressRouteComparator } from './comparator';
+
+describe('comparator', () => {
+  describe('expressRouteComparator', () => {
+    it('should desc sort path by a number of segments', () => {
+      const initMock: [string, ...unknown[]][] = [
+        ['/aaa'],
+        ['/aaa/bbb/ccc'],
+        ['/aaa/bbb'],
+        ['/aaa/ddd/ccc'],
+      ];
+      const expectedMock: [string, ...unknown[]][] = [
+        ['/aaa/bbb/ccc'],
+        ['/aaa/ddd/ccc'],
+        ['/aaa/bbb'],
+        ['/aaa'],
+      ];
+
+      expect(initMock.sort(expressRouteComparator)).toEqual(expectedMock);
+    });
+
+    it('should desc sort path by params and a number of segments', () => {
+      const initMock: [string, ...unknown[]][] = [
+        ['/aaa'],
+        ['/aaa/{param}/ccc'],
+        ['/aaa/{param}'],
+        ['/aaa/ddd'],
+      ];
+      const expectedMock: [string, ...unknown[]][] = [
+        ['/aaa/ddd'],
+        ['/aaa/{param}/ccc'],
+        ['/aaa/{param}'],
+        ['/aaa'],
+      ];
+
+      expect(initMock.sort(expressRouteComparator)).toEqual(expectedMock);
+    });
+  });
+});

--- a/src/utils/comparator.ts
+++ b/src/utils/comparator.ts
@@ -1,0 +1,20 @@
+const isPathParam = (segment: string) => segment.startsWith('{') && segment.endsWith('}');
+
+// eslint-disable-next-line import/prefer-default-export
+export function expressRouteComparator(
+  pathA: [string, ...unknown[]],
+  pathB: [string, ...unknown[]]
+) {
+  const segmentsA = pathA[0].split('/');
+  const segmentsB = pathB[0].split('/');
+
+  for (let i = 0; i < Math.min(segmentsA.length, segmentsB.length); i += 1) {
+    const isParamA = isPathParam(segmentsA[i]);
+    const isParamB = isPathParam(segmentsB[i]);
+
+    if (isParamA && !isParamB) return 1;
+    if (!isParamA && isParamB) return -1;
+  }
+
+  return segmentsB.length - segmentsA.length;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { default as validator } from './validator';
 export * from './generator';
+export * from './comparator';


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Previously, routes like ```/users/{id}``` could potentially match before ```/users/me```, causing the parameterized route to handle requests meant for specific endpoints. This proposal adds a route sorting feature to ensure that routes are prioritized correctly in Express.js

### Breaking Changes

No breaking change.

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
